### PR TITLE
Specify Gemfile when packaging bundle

### DIFF
--- a/lib/capistrano/recipes/deploy/strategy/copy_bundled.rb
+++ b/lib/capistrano/recipes/deploy/strategy/copy_bundled.rb
@@ -66,7 +66,7 @@ module Capistrano
             run_locally "cd #{destination} && #{bundle_cmd} install #{args.join(' ').strip}"
 
             logger.info "packaging gems for bundler in #{destination}..."
-            run_locally "cd #{destination} && #{bundle_cmd} package --all"
+            run_locally "cd #{destination} && #{bundle_cmd} package --all --gemfile #{File.join(destination, bundle_gemfile)}"
           end
         end
       end


### PR DESCRIPTION
It fails if Gemfile is located differently otherwise.